### PR TITLE
Apps.fp.o, Bad Certs, and No Staging

### DIFF
--- a/tests/badcerts.rst
+++ b/tests/badcerts.rst
@@ -1,0 +1,10 @@
+Bad Certificates
+================
+
+Here is a list of the apps from `apps.fp.o <http://apps.fedoraproject.org>`_ that are not amenable to selenium tests due to expired certificates:
+ - `https://ask.stg.fedoraproject.org/questions/`_
+ - `https://docs.stg.fedoraproject.org/en-US/index.html`_
+ - `https://apps.stg.fedoraproject.org/busmon/`_
+ - `https://stg.fedorahosted.org/`_
+ - `https://apps.stg.fedoraproject.org/packages/`_
+ - `https://mirrors.stg.fedoraproject.org/publiclist/`_

--- a/tests/nostage.rst
+++ b/tests/nostage.rst
@@ -1,0 +1,11 @@
+No Staging
+==========
+
+Here is a list of all the sites that do not have a staging equivalent from `apps.fp.o https://apps.fedoraproject.org`_.
+ - `https://bugzilla.redhat.com/`_
+ - `http://status.fedoraproject.org/`_
+ - `https://fedorapeople.org`_
+ - `http://planet.fedoraproject.org/`_
+ - `http://lists.fedoraproject.org/`_
+ - `https://retrace.fedoraproject.org/faf/summary/`_
+ - `http://qa.fedoraproject.org/blockerbugs`_

--- a/tests/test_bodhi.py
+++ b/tests/test_bodhi.py
@@ -1,10 +1,29 @@
-import selenium
+# This file is part of Rube.
+#
+# Rube is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Rube. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Ralph Bean <rbean@redhat.com>
+#     Remy DeCausemaker <remyd@civx.us>
+
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 import unittest
 from nose.tools import eq_, assert_in
 
 from utils import prompt_for_auth
+
 
 class TestBodhi(unittest.TestCase):
     def setUp(self):

--- a/tests/test_collectd.py
+++ b/tests/test_collectd.py
@@ -1,0 +1,37 @@
+# This file is part of Rube.
+#
+# Rube is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Rube. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Ralph Bean <rbean@redhat.com>
+#     Remy DeCausemaker <remyd@civx.us>
+#
+from selenium import webdriver
+import unittest
+from nose.tools import eq_
+
+from utils import prompt_for_auth
+
+
+class TestCollectd(unittest.TestCase):
+    def setUp(self):
+        self.auth = prompt_for_auth("FAS")
+        self.driver = webdriver.Firefox()
+
+    def tearDown(self):
+        self.driver.close()
+
+    def test_title(self):
+        self.driver.get("https://admin.stg.fedoraproject.org/collectd/")
+        eq_("collection.cgi, Version 3", self.driver.title)

--- a/tests/test_easyfix.py
+++ b/tests/test_easyfix.py
@@ -1,0 +1,36 @@
+# This file is part of Rube.
+#
+# Rube is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Rube. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Ralph Bean <rbean@redhat.com>
+#     Remy DeCausemaker <remyd@civx.us>
+#
+from selenium import webdriver
+import unittest
+from nose.tools import eq_
+
+from utils import prompt_for_auth
+
+class TestEasyFix(unittest.TestCase):
+    def setUp(self):
+        self.auth = prompt_for_auth("FAS")
+        self.driver = webdriver.Firefox()
+
+    def tearDown(self):
+        self.driver.close()
+
+    def test_title(self):
+        self.driver.get("https://stg.fedoraproject.org/easyfix/")
+        eq_("Fedora Project easyfix", self.driver.title)

--- a/tests/test_easyfix.py
+++ b/tests/test_easyfix.py
@@ -16,12 +16,13 @@
 # Authors:
 #     Ralph Bean <rbean@redhat.com>
 #     Remy DeCausemaker <remyd@civx.us>
-#
+
 from selenium import webdriver
 import unittest
 from nose.tools import eq_
 
 from utils import prompt_for_auth
+
 
 class TestEasyFix(unittest.TestCase):
     def setUp(self):

--- a/tests/test_elections.py
+++ b/tests/test_elections.py
@@ -1,0 +1,37 @@
+# This file is part of Rube.
+#
+# Rube is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Rube. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Ralph Bean <rbean@redhat.com>
+#     Remy DeCausemaker <remyd@civx.us>
+
+from selenium import webdriver
+import unittest
+from nose.tools import eq_
+
+from utils import prompt_for_auth
+
+
+class TestElections(unittest.TestCase):
+    def setUp(self):
+        self.auth = prompt_for_auth("FAS")
+        self.driver = webdriver.Firefox()
+
+    def tearDown(self):
+        self.driver.close()
+
+    def test_title(self):
+        self.driver.get("https://admin.stg.fedoraproject.org/voting")
+        eq_("Fedora Elections", self.driver.title)

--- a/tests/test_haproxy.py
+++ b/tests/test_haproxy.py
@@ -1,0 +1,37 @@
+# This file is part of Rube.
+#
+# Rube is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Rube. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Ralph Bean <rbean@redhat.com>
+#     Remy DeCausemaker <remyd@civx.us>
+#
+from selenium import webdriver
+import unittest
+from nose.tools import eq_
+
+from utils import prompt_for_auth
+
+
+class TestHAProxy(unittest.TestCase):
+    def setUp(self):
+        self.auth = prompt_for_auth("FAS")
+        self.driver = webdriver.Firefox()
+
+    def tearDown(self):
+        self.driver.close()
+
+    def test_title(self):
+        self.driver.get("https://admin.stg.fedoraproject.org/haproxy/proxy1")
+        eq_("Statistics Report for HAProxy", self.driver.title)

--- a/tests/test_koji.py
+++ b/tests/test_koji.py
@@ -16,12 +16,13 @@
 # Authors:
 #     Ralph Bean <rbean@redhat.com>
 #     Remy DeCausemaker <remyd@civx.us>
-#
+
 from selenium import webdriver
 import unittest
 from nose.tools import eq_
 
 from utils import prompt_for_auth
+
 
 class TestKoji(unittest.TestCase):
     def setUp(self):

--- a/tests/test_nagios.py
+++ b/tests/test_nagios.py
@@ -1,0 +1,37 @@
+# This file is part of Rube.
+#
+# Rube is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Rube. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Ralph Bean <rbean@redhat.com>
+#     Remy DeCausemaker <remyd@civx.us>
+#
+from selenium import webdriver
+import unittest
+from nose.tools import eq_
+
+from utils import prompt_for_auth
+
+
+class TestNagios(unittest.TestCase):
+    def setUp(self):
+        self.auth = prompt_for_auth("FAS")
+        self.driver = webdriver.Firefox()
+
+    def tearDown(self):
+        self.driver.close()
+
+    def test_title(self):
+        self.driver.get("https://admin.stg.fedoraproject.org/nagios/")
+        eq_("Nagios Core", self.driver.title)

--- a/tests/test_paste.py
+++ b/tests/test_paste.py
@@ -1,0 +1,37 @@
+# This file is part of Rube.
+#
+# Rube is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Rube. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Ralph Bean <rbean@redhat.com>
+#     Remy DeCausemaker <remyd@civx.us>
+#
+from selenium import webdriver
+import unittest
+from nose.tools import assert_in
+
+from utils import prompt_for_auth
+
+
+class TestFPaste(unittest.TestCase):
+    def setUp(self):
+        self.auth = prompt_for_auth("FAS")
+        self.driver = webdriver.Firefox()
+
+    def tearDown(self):
+        self.driver.close()
+
+    def test_title(self):
+        self.driver.get("http://paste.stg.fedoraproject.org/")
+        assert_in("New paste", self.driver.title)

--- a/tests/test_pkgdb.py
+++ b/tests/test_pkgdb.py
@@ -1,0 +1,37 @@
+# This file is part of Rube.
+#
+# Rube is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Rube. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Ralph Bean <rbean@redhat.com>
+#     Remy DeCausemaker <remyd@civx.us>
+
+from selenium import webdriver
+import unittest
+from nose.tools import eq_
+
+from utils import prompt_for_auth
+
+
+class TestPkgDb(unittest.TestCase):
+    def setUp(self):
+        self.auth = prompt_for_auth("FAS")
+        self.driver = webdriver.Firefox()
+
+    def tearDown(self):
+        self.driver.close()
+
+    def test_title(self):
+        self.driver.get("https://admin.stg.fedoraproject.org/pkgdb")
+        eq_("Fedora Package Database", self.driver.title)

--- a/tests/test_pkgs.py
+++ b/tests/test_pkgs.py
@@ -1,0 +1,37 @@
+# This file is part of Rube.
+#
+# Rube is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Rube is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Rube. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Ralph Bean <rbean@redhat.com>
+#     Remy DeCausemaker <remyd@civx.us>
+
+from selenium import webdriver
+import unittest
+from nose.tools import eq_
+
+from utils import prompt_for_auth
+
+
+class TestPkgs(unittest.TestCase):
+    def setUp(self):
+        self.auth = prompt_for_auth("FAS")
+        self.driver = webdriver.Firefox()
+
+    def tearDown(self):
+        self.driver.close()
+
+    def test_title(self):
+        self.driver.get("http://pkgs.stg.fedoraproject.org/cgit")
+        eq_("Fedora Project Packages GIT repositories", self.driver.title)


### PR DESCRIPTION
Added tests for the rest of the apps listed on https://apps.fedoraproject.org.
Added a listing of all sites with bad SSL certificates listed on https://apps.fedoraproject.org.
Added a listing of all sites without a staging equivalent on https://apps.fedoraproject.org.
