### PR TITLE
The blockerbugs login link is weird.

### DIFF
--- a/rube.fedora/rube/fedora/test_blockerbugs.py
+++ b/rube.fedora/rube/fedora/test_blockerbugs.py
@@ -27,9 +27,7 @@ class TestBlockerBugs(rube.fedora.FedoraRubeTest):
 
     @rube.core.tolerant()
     def test_stuff(self):
-        self.driver.get(self.base)
-        elem = self.driver.find_element_by_css_selector('.login-link')
-        elem.click()
+        self.driver.get(self.base + "/login")
         elem = self.driver.find_element_by_name('username')
         elem.send_keys(self.auth[0])
         elem = self.driver.find_element_by_name('password')


### PR DESCRIPTION
This selenium code to go and click on the login link used to work, but
now it just hangs.  Let's just get around it by going directly to the
login page.  This works.
