### PR TITLE
HAR Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg*
 dist
 build
+harfiles

--- a/rube.core/README.rst
+++ b/rube.core/README.rst
@@ -30,6 +30,20 @@ Running
    in setup.cfg.  Doing so will require that you have
    ``xorg-x11-server-Xvfb`` installed via yum, however.
 
+.. note:: Collecting HAR files for performance metrics.
+
+   Rube will output harfile data into a ``harfiles/`` directory if
+   you turn on ``collect-har`` and specify a ``path`` to
+   `browsermob-proxy <http://bmp.lightbody.net>`_ in the
+   ``[browsermob]`` section of your setup.cfg file.
+
+   You'll also need to manually ``pip install browsermob-proxy``
+   into your virtualenv.  Note that `this patch
+   <https://github.com/AutomatedTester/browsermob-proxy-py/pull/13>`_
+   is required to collect HAR files from https sites (such as our
+   entire infrastructure).
+
+
 Covered Services
 ----------------
 

--- a/rube.core/rube/core/utils.py
+++ b/rube.core/rube/core/utils.py
@@ -14,8 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Rube.  If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
 import vault
 import sys
+import os
+import json
 import nose.tools.nontrivial
 import threading
 import time
@@ -25,6 +28,8 @@ from functools import wraps
 from testconfig import config
 
 _cache = {}
+
+import_time = datetime.datetime.now()
 
 
 def prompt_for_auth(service):
@@ -89,6 +94,7 @@ def expects_zmqmsg(topic, timeout=20000):
 
     def decorate(func):
         name = func.__name__
+
         @wraps(func)
         def newfunc(*args, **kw):
             t = ZmqmsgListener(topic, timeout)
@@ -133,6 +139,56 @@ def tolerant(n=3):
 
         newfunc = nose.tools.nontrivial.make_decorator(func)(newfunc)
         return newfunc
+    return decorate
+
+
+def _write_harfile(namespace, har):
+    """ Utility to write out files for the @collect_har decorator. """
+
+    hardir = "harfiles"
+
+    if not os.path.exists(hardir):
+        os.makedirs(hardir)
+
+    fname = os.path.join(
+        hardir,
+        namespace + '-' + import_time.isoformat() + '.har'
+    )
+
+    with open(fname, 'w') as f:
+        f.write(json.dumps(har))
+
+    print " * Wrote", fname
+
+
+def collect_har():
+    """ A decorator.  If applied, the wrapped test will produce HAR
+    output files marked by both the provided ``namespace`` and the
+    current datetime.
+
+    This presumes that browsermob-proxy is installed and available on
+    the tested function's bound object as an attribute: ``proxy``.
+    """
+
+    def decorate(func):
+
+        @wraps(func)
+        def newfunc(self, *args, **kw):
+            namespace = self.base.replace(':', '').replace('/', '-')
+            if self.proxy:
+                self.proxy.new_har(namespace)
+
+            result = func(self, *args, **kw)
+
+            if self.proxy:
+                har = self.proxy.har()
+                _write_harfile(namespace, har)
+
+            return result
+
+        newfunc = nose.tools.nontrivial.make_decorator(func)(newfunc)
+        return newfunc
+
     return decorate
 
 

--- a/rube.core/rube/core/utils.py
+++ b/rube.core/rube/core/utils.py
@@ -147,13 +147,11 @@ def _write_harfile(namespace, har):
 
     hardir = "harfiles"
 
-    if not os.path.exists(hardir):
-        os.makedirs(hardir)
+    dirname = os.path.join(hardir, namespace)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
 
-    fname = os.path.join(
-        hardir,
-        namespace + '-' + import_time.isoformat() + '.har'
-    )
+    fname = os.path.join(dirname, import_time.isoformat() + '.har')
 
     with open(fname, 'w') as f:
         f.write(json.dumps(har))

--- a/rube.core/setup.cfg
+++ b/rube.core/setup.cfg
@@ -11,3 +11,11 @@ headless=0
 
 [zeromq]
 endpoint=tcp://stg.fedoraproject.org:9940
+
+[browsermob]
+# Uncomment this to collect harfiles
+#collect-har=1
+
+# You'll need to download browsermob-proxy yourself and
+# pip install the browsermob-proxy python bindings.
+#path=/home/threebean/rpmbuild/SOURCES/browsermob-proxy-2.0-beta-8/bin/browsermob-proxy

--- a/rube.fedora/setup.cfg
+++ b/rube.fedora/setup.cfg
@@ -11,3 +11,8 @@ headless=0
 
 [zeromq]
 endpoint=tcp://stg.fedoraproject.org:9940
+
+[browsermob]
+# Uncomment this to collect harfiles
+collect-har=1
+path=/home/threebean/rpmbuild/SOURCES/browsermob-proxy-2.0-beta-8/bin/browsermob-proxy

--- a/rube.fedora/setup.cfg
+++ b/rube.fedora/setup.cfg
@@ -14,5 +14,5 @@ endpoint=tcp://stg.fedoraproject.org:9940
 
 [browsermob]
 # Uncomment this to collect harfiles
-collect-har=1
-path=/home/threebean/rpmbuild/SOURCES/browsermob-proxy-2.0-beta-8/bin/browsermob-proxy
+#collect-har=1
+#path=/home/threebean/rpmbuild/SOURCES/browsermob-proxy-2.0-beta-8/bin/browsermob-proxy

--- a/rube.fedora/setup.cfg
+++ b/rube.fedora/setup.cfg
@@ -15,4 +15,7 @@ endpoint=tcp://stg.fedoraproject.org:9940
 [browsermob]
 # Uncomment this to collect harfiles
 #collect-har=1
+
+# You'll need to download browsermob-proxy yourself and
+# pip install the browsermob-proxy python bindings.
 #path=/home/threebean/rpmbuild/SOURCES/browsermob-proxy-2.0-beta-8/bin/browsermob-proxy


### PR DESCRIPTION
This adds HAR file support for rube.  If configured to do so, rube will drop har files for each site in a `harfiles/` directory.  We can later use those files to graph performance over time or to debug why certain pages load slowly.

It is turned off by default since you need to manually download browsermob-proxy and a patched version of the python bindings.
