### PR TITLE
Add a new decorator for calling a function after a test has run.

### DIFF
--- a/rube.core/rube/core/__init__.py
+++ b/rube.core/rube/core/__init__.py
@@ -31,6 +31,7 @@ from utils import (
     tolerant,
     skip_logout,
     collect_har,
+    ensures_after,
 )
 
 selenium_logger = logging.getLogger("selenium.webdriver")

--- a/rube.core/rube/core/tests/test_self.py
+++ b/rube.core/rube/core/tests/test_self.py
@@ -32,3 +32,24 @@ def test_expects_fedmsg():
 @rube.core.tolerant()
 def test_tolerant():
     raise AssertionError("This should fail")
+
+
+def fail():
+    assert False
+
+
+def win():
+    assert True
+
+
+@raises(AssertionError)
+@rube.core.ensures_after(fail)
+def test_after_callable_failure():
+    """ Test that the after callable correctly fails. """
+    pass
+
+
+@rube.core.ensures_after(win)
+def test_after_callable_success():
+    """ Test that the after callable doesn't give false positives. """
+    pass


### PR DESCRIPTION
@gregjurman, this is what I was talking about at Flock.  It's a little more generic than expecting just a shell command.  It could be re-used for lots of purposes.
