### PR TITLE
Monkey patch tests to make them skippable.

### DIFF
--- a/rube.core/rube/core/utils.py
+++ b/rube.core/rube/core/utils.py
@@ -162,6 +162,8 @@ def tolerant(n=3):
             for i in range(n):
                 try:
                     return func(*args, **kw)
+                except KeyboardInterrupt:
+                    raise
                 except Exception as e:
                     traceback.print_exc()
                     if not original_exception:


### PR DESCRIPTION
@puiterwijk and I cooked this up at Flock!

This makes it so that you can ctrl-C during any test and it will be
marked as SKIPPED instead of failing the whole test suite.  This is
especially nice if we have a service that we know happens to be broken
or if there's a service that is temporarily hung (or uninteresting or
whatever).

:bird: flocktofedora :bird:
