### PR TITLE
New selenium requires geckodriver to be in PATH.

### DIFF
--- a/rube.core/requirements.txt
+++ b/rube.core/requirements.txt
@@ -1,5 +1,5 @@
 vault
-selenium
+selenium<3
 nose
 pyzmq
 nose-timer

--- a/rube.fedora/requirements.txt
+++ b/rube.fedora/requirements.txt
@@ -1,1 +1,2 @@
 rube.core
+selenium<3


### PR DESCRIPTION
selenium > 3.x just plain fails to run.
